### PR TITLE
Fix node selector, check if nodes are found

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 )
 
 var (
@@ -23,13 +24,43 @@ type Proxy struct {
 }
 
 func New(logger *slog.Logger, name string, domain string) (*Proxy, error) {
+	if name == "" {
+		return nil, fmt.Errorf("installation name cannot be empty")
+	}
+	if domain == "" {
+		return nil, fmt.Errorf("domain cannot be empty")
+	}
+
 	port := startPort
 	startPort++ // Increment the port for the next proxy
 
+	selector := fmt.Sprintf("ins=%s,cluster=%s,role=control-plane", name, name)
+
+	// Detect available nodes by executing `tsh ls --format=names ins=MC_NAME,cluster=MC_NAME,role=control-plane`
+	cmd := exec.Command("tsh", "ls", "--format=names", selector)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if ok {
+			logger.Debug("Node listing failed",
+				slog.String("name", name),
+				slog.Int("exit_code", exitErr.ExitCode()),
+				slog.String("output", string(output)))
+			return nil, fmt.Errorf("nodes could not be listed: %v", err)
+		}
+		return nil, fmt.Errorf("failed to check installation %s: %v", name, err)
+	}
+	nodes := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(nodes) == 0 || (len(nodes) == 1 && nodes[0] == "") {
+		return nil, fmt.Errorf("no nodes found for installation %s", name)
+	}
+
+	logger.Debug("Nodes for installation", slog.Int("count", len(nodes)), slog.String("name", name), slog.String("nodes", strings.Join(nodes, ", ")))
+
 	logger.Info("Starting proxy", slog.String("name", name), slog.String("domain", domain), slog.Int("port", port))
-	host := fmt.Sprintf("root@role=control-plane,mc=%s", name)
+	host := fmt.Sprintf("root@%s", selector)
 	//nolint:gosec
-	err := exec.Command(
+	err = exec.Command(
 		"tsh",
 		"ssh",
 		"--no-remote-exec",


### PR DESCRIPTION
This PR fixes the node selector to the `tsh ssh` command. Previously it was:

    mc=MC_NAME,role=control-plane

However, this returned all CP nodes from all clusters, not just the management cluster. The selector should instead be:

    ins=MC_NAME,cluster=MC_NAME,role=control-plane

In addition, the `proxy.New()` function now performs a check whether nodes are found for the installation.